### PR TITLE
Create Private ALB for Azure HA INC mode Cloud Native VPX deployments

### DIFF
--- a/azure/ha_availability_zones/README.md
+++ b/azure/ha_availability_zones/README.md
@@ -116,3 +116,23 @@ is removed the bastion host is the only other way to access the NSIP.
 
 This means all SSH and NITRO API calls will have to be executed from
 the bastion host.
+
+# Cloud Native Deployments
+
+For Cloud Native Deployments where the use case is that a Citrix ADC VPX outside the Kubernetes cluster acts as Ingress, please set the variable `create_ILB_for_management` to `true`
+
+Sample Terraform Variable file below
+
+```
+resource_group_name="my-ha-inc-rg"
+location="southeastasia"
+virtual_network_address_space="192.168.0.0/16"
+management_subnet_address_prefix="192.168.0.0/24"
+client_subnet_address_prefix="192.168.1.0/24"
+server_subnet_address_prefix="192.168.2.0/24"
+adc_admin_password="<Provide a strong VPX Password>"
+controlling_subnet="<CIDR to allow Management Access>"
+create_ILB_for_management=true
+```
+
+For more information on Cloud Native Deployments, please see [Citrix Ingress Controller GitHub](https://github.com/citrix/citrix-k8s-ingress-controller)

--- a/azure/ha_availability_zones/azure_internal_lb_nsip/azure_internal_load_balancer_nsip.tf
+++ b/azure/ha_availability_zones/azure_internal_lb_nsip/azure_internal_load_balancer_nsip.tf
@@ -1,0 +1,102 @@
+###############################
+#    Private ALB for NSIP     #
+###############################
+
+resource "azurerm_network_interface_backend_address_pool_association" "tf_nsip_assoc" {
+  network_interface_id    = element(var.citrixadc_management_nic.*.id, count.index)
+
+  ip_configuration_name   = "management"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.tf_internal_backend_pool.id
+
+  count = 2
+}
+
+resource "azurerm_lb_rule" "allow_http_nsip" {
+  resource_group_name            = var.resource_group_name
+  loadbalancer_id                = azurerm_lb.tf_internal_lb.id
+  name                           = "NitroHTTPRule"
+  protocol                       = "Tcp"
+  frontend_port                  = 80
+  backend_port                   = 80
+  frontend_ip_configuration_name = "PrivateIPAddress"
+  enable_floating_ip             = true
+  idle_timeout_in_minutes        = 4
+  load_distribution              = "Default"
+  probe_id                       = azurerm_lb_probe.tf_internal_probe.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.tf_internal_backend_pool.id
+
+}
+
+resource "azurerm_lb_rule" "allow_https_nsip" {
+  resource_group_name            = var.resource_group_name
+  loadbalancer_id                = azurerm_lb.tf_internal_lb.id
+  name                           = "NitroHTTPSRule"
+  protocol                       = "Tcp"
+  frontend_port                  = 443
+  backend_port                   = 443
+  frontend_ip_configuration_name = "PrivateIPAddress"
+  enable_floating_ip             = true
+  idle_timeout_in_minutes        = 4
+  load_distribution              = "Default"
+  probe_id                       = azurerm_lb_probe.tf_internal_probe.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.tf_internal_backend_pool.id
+}
+
+resource "azurerm_lb_backend_address_pool" "tf_internal_backend_pool" {
+
+  resource_group_name = var.resource_group_name
+  loadbalancer_id     = azurerm_lb.tf_internal_lb.id
+  name                = "BackEndAddressPool"
+}
+
+resource "azurerm_lb_probe" "tf_internal_probe" {
+
+  resource_group_name = var.resource_group_name
+  loadbalancer_id     = azurerm_lb.tf_internal_lb.id
+  name                = "nsip-http-probe"
+  port                = 9000
+  protocol            = "Tcp"
+  interval_in_seconds = 5
+  number_of_probes    = 2
+}
+
+resource "azurerm_lb" "tf_internal_lb" {
+
+  name                = "tf_internal_lb"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = "Standard"
+
+  frontend_ip_configuration {
+    name                 = "PrivateIPAddress"
+    subnet_id            = var.management_subnet_id
+  }
+}
+
+resource "null_resource" "cic_nsip_config_citrix_adc" {
+  connection {
+    host = var.bastion_public_ip
+    user = var.ubuntu_admin_user
+    # Should be the private key corresponding to the one used for creating the ubuntu node
+    private_key = file(var.ssh_private_key_file)
+  }
+
+  depends_on = [
+    azurerm_lb.tf_internal_lb
+  ]
+
+  provisioner "remote-exec" {
+    inline = [
+      format("curl -s -k -H \"Content-Type: application/json\" -H \"X-NITRO-USER: %v\" -H \"X-NITRO-PASS: %v\" -d %#v https://%v/nitro/v1/config/nsip", var.adc_admin_username, var.adc_admin_password, jsonencode(
+        {nsip={
+          ipaddress=azurerm_lb.tf_internal_lb.private_ip_address,
+          netmask=var.citrixadc_management_netmask,
+          type="SNIP",
+          mgmtaccess="ENABLED"
+        }}
+      ), var.citrixadc_nsips[count.index])
+    ]
+  }
+
+  count = length(var.citrixadc_nsips)
+}

--- a/azure/ha_availability_zones/azure_internal_lb_nsip/outputs.tf
+++ b/azure/ha_availability_zones/azure_internal_lb_nsip/outputs.tf
@@ -1,0 +1,4 @@
+output "cic_nsip" {
+  value = azurerm_lb.tf_internal_lb.private_ip_address
+}
+

--- a/azure/ha_availability_zones/azure_internal_lb_nsip/variables.tf
+++ b/azure/ha_availability_zones/azure_internal_lb_nsip/variables.tf
@@ -1,0 +1,47 @@
+variable "resource_group_name" {
+  description = "Name for the resource group that will contain all created resources"
+  default     = "terraform-resource-group"
+}
+
+variable "location" {
+  description = "Azure location where all resources will be created"
+}
+
+variable "management_subnet_id" {
+  description = "Azure management Networks ID"
+}
+
+variable "citrixadc_management_nic" {
+  description = "Management NIC of Citrix ADC"
+}
+
+variable "citrixadc_nsips" {
+  description = "Management IPs of Citrix ADC"
+}
+
+variable "citrixadc_management_netmask" {
+  description = "Subnet Mask for Citrix ADC Management Subnet"
+}
+
+variable "adc_admin_username" {
+  description = "User name for the Citrix ADC admin user."
+  default     = "nsroot"
+}
+
+variable "adc_admin_password" {
+  description = "Password for the Citrix ADC admin user. Must be sufficiently complex to pass azurerm provider checks."
+}
+
+variable "bastion_public_ip" {
+  description = "Public IP of the created Bastion Server"
+  
+}
+
+variable "ubuntu_admin_user" {
+  description = "The Admin Username of the created Bastion Server"
+}
+
+variable "ssh_private_key_file" {
+  description = "Private key file for accessing the ubuntu bastion machine."
+  default     = "~/.ssh/id_rsa"
+}

--- a/azure/ha_availability_zones/outputs.tf
+++ b/azure/ha_availability_zones/outputs.tf
@@ -25,3 +25,7 @@ output "bastion_public_ip" {
 output "alb_public_ip" {
   value = azurerm_public_ip.terraform-load-balancer-public-ip.ip_address
 }
+
+output "cic_nsip" {
+  value = module.azure_ilb_nsip
+}

--- a/azure/ha_availability_zones/variables.tf
+++ b/azure/ha_availability_zones/variables.tf
@@ -37,6 +37,11 @@ variable "ssh_public_key_file" {
   default     = "~/.ssh/id_rsa.pub"
 }
 
+variable "ssh_private_key_file" {
+  description = "Private key file for accessing the ubuntu bastion machine."
+  default     = "~/.ssh/id_rsa"
+}
+
 variable "ubuntu_vm_size" {
   description = "Size for the ubuntu machine."
   default     = "Standard_A1_v2"
@@ -54,4 +59,9 @@ variable "controlling_subnet" {
 variable "adc_vm_size" {
   description = "Size for the ADC machine. Must allow for 3 NICs."
   default     = "Standard_F8s_v2"
+}
+
+variable "create_ILB_for_management" {
+  description = "Set this variable to true if an ILB is required for VPX NSIPs"
+  default = false
 }


### PR DESCRIPTION
For Cloud Native Deployments, we need an Internal ALB that would be used by CIC to configure the Citrix ADC VPX.
This PR adds support for creating an Internal ALB. This is made optional by using a variable whose default value is "false". 
I have made this entire functionality as a module so that it can be easily toggled and wouldn't affect the existing functionality.
Since this module would be executed after Citrix ADC creation, I am firing Nitro commands from bastion to create SNIP on VPX.
